### PR TITLE
BUGFIX - Segment Drift stories glitch and parquet file download issue

### DIFF
--- a/query_manager/query_manager/config.py
+++ b/query_manager/query_manager/config.py
@@ -36,8 +36,8 @@ class Settings(BaseSettings):
     SERVER_HOST: str | AnyHttpUrl
     PAGINATION_PER_PAGE: int = 20
 
-    AWS_BUCKET: str = "fulcrum-engine-metrics"
-    AWS_REGION: str = "us-east-1"
+    AWS_BUCKET: str = "fulcrum-metrics-pq"
+    AWS_REGION: str = "us-west-1"
 
     BACKEND_CORS_ORIGINS: list[AnyHttpUrl | str] = []
 

--- a/story_manager/story_manager/story_builder/plugins/segment_drift.py
+++ b/story_manager/story_manager/story_builder/plugins/segment_drift.py
@@ -190,7 +190,7 @@ class SegmentDriftStoryBuilder(StoryBuilderBase):
                 "previous_share": round(dimension_slice["comparison_value"]["slice_share"]),
                 "current_share": round(dimension_slice["evaluation_value"]["slice_share"]),
                 "dimension": metric_dimensions[dimension_slice["key"][0]["dimension"]],
-                "slice_name": dimension_slice["key"][0]["value"],
+                "slice": dimension_slice["key"][0]["value"],
                 "slice_share_change_percentage": round(dimension_slice["slice_share_change_percentage"]),
                 "pressure_direction": dimension_slice["pressure"].lower(),
                 "previous_value": round(dimension_slice["comparison_value"]["slice_value"]),


### PR DESCRIPTION
## Description of the change

> Segment Drift Story fix for 'null' segment name in story title and parquet file download fix

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
> Fix [#1]()

## Checklists
- [ ] Add the Linear ticket number in the title
- [ ] Add screenshots when applicable

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
