### PR TITLE
fix: Add missing await in story manager CRUD operations (Fixes STORY-MANAGER-9)

### DIFF
--- a/story_manager/story_manager/core/crud.py
+++ b/story_manager/story_manager/core/crud.py
@@ -80,7 +80,7 @@ class CRUDStory(CRUDBase[Story, Story, Story, StoryFilter]):
         result = await self.session.execute(statement=statement)
 
         # Get the unique result or None if no result is found
-        instance: Story | None = result.unique().scalar_one_or_none()  # noqa
+        instance: Story | None = await result.unique().scalar_one_or_none()  # noqa
 
         return instance
 
@@ -217,7 +217,7 @@ class CRUDStoryConfig(CRUDBase[StoryConfig, StoryConfig, StoryConfig, StoryConfi
         results = await self.session.execute(statement=statement)
 
         # Get the unique result or None if no result is found
-        instance: StoryConfig | None = results.unique().scalar_one_or_none()  # noqa
+        instance: StoryConfig | None = await results.unique().scalar_one_or_none()  # noqa
 
         # Return the StoryConfig instance or None
         return instance


### PR DESCRIPTION
## 🐛 Bug Fix

### Description
This PR fixes the `AttributeError: 'coroutine' object has no attribute 'scalar_one_or_none'` error occurring in the story_manager service during story upsert operations.

### Root Cause
The error was caused by missing `await` keywords when calling `scalar_one_or_none()` on async SQLAlchemy query results. Without the await, Python was trying to call the method on a coroutine object instead of the actual database result.

### Changes Made
- ✅ Added `await` keyword in `get_latest_story` method (line 78)
- ✅ Added `await` keyword in `get_story_config` method (line 211)

### Files Changed
- `story_manager/story_manager/core/crud.py`

### Error Details
- **Sentry Issue**: [STORY-MANAGER-9](https://levers-labs.sentry.io/issues/6884913342/)
- **Occurrences**: 5 times between 05:46-06:38 UTC on Sep 18, 2025
- **Impact**: Story upsert operations were failing in production

### Testing
Please verify:
- [ ] Story upsert operations complete successfully
- [ ] No AttributeError in logs
- [ ] Unit tests pass
- [ ] Integration tests for async CRUD operations pass

### Risk Assessment
**Risk Level**: Very Low
- Simple one-line fixes with clear resolution
- Pattern validated in base CRUD class
- Same pattern correctly used in other methods

### References
- Follows the async/await pattern used in `commons/db/crud.py`
- Aligns with SQLAlchemy async session documentation

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>