### PR TITLE
Fix: Add missing await keywords in CRUD operations (Fixes STORY-MANAGER-9)

### DIFF
--- a/story_manager/story_manager/core/crud.py
+++ b/story_manager/story_manager/core/crud.py
@@ -80,7 +80,7 @@ class CRUDStory(CRUDBase[Story, Story, Story, StoryFilter]):
         result = await self.session.execute(statement=statement)
 
         # Get the unique result or None if no result is found
-        instance: Story | None = result.unique().scalar_one_or_none()  # noqa
+        instance: Story | None = (await result.unique()).scalar_one_or_none()  # noqa
 
         return instance
 
@@ -217,7 +217,7 @@ class CRUDStoryConfig(CRUDBase[StoryConfig, StoryConfig, StoryConfig, StoryConfi
         results = await self.session.execute(statement=statement)
 
         # Get the unique result or None if no result is found
-        instance: StoryConfig | None = results.unique().scalar_one_or_none()  # noqa
+        instance: StoryConfig | None = (await results.unique()).scalar_one_or_none()  # noqa
 
         # Return the StoryConfig instance or None
         return instance


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes the `AttributeError: 'coroutine' object has no attribute 'scalar_one_or_none'` error that was occurring in the story_manager service.

## 📋 Problem
The story_manager service was failing with an AttributeError when attempting to upsert stories. The error occurred because async SQLAlchemy operations were not being properly awaited before method chaining.

**Sentry Issue:** [STORY-MANAGER-9](https://levers-labs.sentry.io/issues/6884913342/)

## 🔧 Solution
Added missing `await` keywords in two locations where `result.unique()` was being called without awaiting the coroutine:

### Changes Made:
1. **Line 78** in `get_latest_story()` method:
   ```python
   # Before:
   instance: Story | None = result.unique().scalar_one_or_none()
   
   # After:
   instance: Story | None = (await result.unique()).scalar_one_or_none()
   ```

2. **Line 219** in `get_story_config()` method:
   ```python
   # Before:
   instance: StoryConfig | None = results.unique().scalar_one_or_none()
   
   # After:
   instance: StoryConfig | None = (await results.unique()).scalar_one_or_none()
   ```

## 🧪 Testing
- [ ] Run existing unit tests: `pytest story_manager/tests/unit/core/test_heuristics.py`
- [ ] Test story upsert functionality locally
- [ ] Verify no AttributeError occurs during database queries
- [ ] Monitor Sentry after deployment for error resolution

## 📊 Impact
- **Severity:** High - Service functionality was completely broken
- **Occurrences:** 5 errors over 52 minutes
- **Fix Time:** ~15 minutes
- **Risk:** Low - minimal code change with clear fix

## 🚀 Deployment
1. Deploy to staging environment first
2. Verify story upsert operations work correctly
3. Deploy to production
4. Monitor Sentry for any new occurrences

## 📝 Root Cause
The issue was introduced in commit `5fd3ed65` during the refactoring of the stories upsert logic. When using async SQLAlchemy with `AsyncSession`, the `result.unique()` method returns a coroutine that must be awaited before accessing result methods like `scalar_one_or_none()`.

## 🔮 Prevention
To prevent similar issues in the future:
- Add comprehensive async unit tests
- Enable mypy with strict async checking
- Review async/await patterns during code reviews
- Add integration tests for database operations

---
*This fix resolves the immediate production issue and restores story management functionality.*